### PR TITLE
Truly properly encode copy URL

### DIFF
--- a/fancyindex.js
+++ b/fancyindex.js
@@ -110,7 +110,7 @@ function clickGetInfo(id) {
 
     var url = window.location.href;
     url = url.substr(0, url.lastIndexOf("/") + 1);
-    dialog.setAttribute("url", encodeURI(decodeURI(url) + lib).replace('#', '%23'));
+    dialog.setAttribute("url", url + encodeURIComponent(lib));
 
     //search info and insert into dialog
     dialog.showModal();


### PR DESCRIPTION
Properly encode URI via encodeURIComponent. Previous implementation left unencoded characters, resulting in 404. Tested against latest fancyindex which includes URL encoding fixes.